### PR TITLE
Add independent column filters for interest levels

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
 import { Briefcase, Plus } from "lucide-react";
@@ -13,6 +13,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 
@@ -35,6 +42,13 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<string>("All");
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
@@ -51,6 +65,21 @@ function KanbanColumn({
           {prospects.length}
         </Badge>
       </div>
+      <div className="px-2 pt-2">
+        <Select value={interestFilter} onValueChange={setInterestFilter}>
+          <SelectTrigger className="h-7 text-xs w-full">
+            <SelectValue placeholder="All" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="All">All</SelectItem>
+            {INTEREST_LEVELS.map((level) => (
+              <SelectItem key={level} value={level}>
+                {level}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
           {isLoading ? (
@@ -58,12 +87,14 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
+          ) : filteredProspects.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+              <p className="text-xs text-muted-foreground">
+                {interestFilter === "All" ? "No prospects" : `No ${interestFilter} interest prospects`}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}


### PR DESCRIPTION
Integrates client-side filtering in `home.tsx` using `useState` and a new `Select` component for each `KanbanColumn`, enabling users to filter prospects by interest level without API calls.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 78693862-96ab-45ca-91db-b8ad33ce6082
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 7865649f-6edf-4211-83e6-2685a898fcf4
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/cf8d72b5-55cb-418d-923a-afaced691013/78693862-96ab-45ca-91db-b8ad33ce6082/XonGcL4
Replit-Helium-Checkpoint-Created: true